### PR TITLE
Status Events

### DIFF
--- a/examples/sqlite/debug.rs
+++ b/examples/sqlite/debug.rs
@@ -157,9 +157,15 @@ fn main() {
         .run();
 }
 
-fn watch_status(mut statuses: EventReader<SqlxEventStatus<Sqlite, Foo>>) {
-    for status in statuses.read() {
-        dbg!({ "status"; status });
+fn watch_status(
+    mut foo_statuses: EventReader<SqlxEventStatus<Sqlite, Foo>>,
+    mut bar_statuses: EventReader<SqlxEventStatus<Sqlite, Bar>>,
+) {
+    for foo_status in foo_statuses.read() {
+        dbg!({ "Foo status"; foo_status });
+    }
+    for bar_status in bar_statuses.read() {
+        dbg!({ "Bar status"; bar_status });
     }
 }
 
@@ -168,10 +174,10 @@ fn detect_changed(
     bar_query: Query<(Entity, &Bar), Changed<Bar>>,
 ) {
     for foo in &foo_query {
-        dbg!({ "foo changed"; &foo});
+        dbg!({ "Foo changed"; &foo});
     }
     for bar in &bar_query {
-        dbg!({ "bar changed"; &bar});
+        dbg!({ "Bar changed"; &bar});
     }
 }
 

--- a/examples/sqlite/debug.rs
+++ b/examples/sqlite/debug.rs
@@ -2,12 +2,11 @@ use std::sync::Arc;
 use rand::prelude::*;
 use bevy::prelude::*;
 use bevy_inspector_egui::quick::WorldInspectorPlugin;
-use sqlx::{FromRow, Sqlite, sqlite::SqliteRow};
+use sqlx::{FromRow, Sqlite};
 use bevy_sqlx::{
     SqlxPlugin,
     SqlxEvent,
     SqlxEventStatus,
-    SqlxComponent,
     PrimaryKey,
 };
 
@@ -34,7 +33,6 @@ impl Plugin for FooPlugin {
         let url = "sqlite:db/sqlite.db";
         app.add_plugins(SqlxPlugin::<Sqlite, Foo>::url(url));
         app.add_systems(Update, Self::send_foo_events);
-        app.observe(handle_trigger::<Foo>);
     }
 }
 
@@ -99,7 +97,6 @@ impl Plugin for BarPlugin {
         let url = "sqlite:db/sqlite.db";
         app.add_plugins(SqlxPlugin::<Sqlite, Bar>::url(&url));
         app.add_systems(Update, Self::send_bar_events);
-        app.observe(handle_trigger::<Bar>);
     }
 }
 
@@ -166,26 +163,16 @@ fn watch_status(mut statuses: EventReader<SqlxEventStatus<Sqlite, Foo>>) {
     }
 }
 
-fn handle_trigger<C: SqlxComponent<SqliteRow>>
-(trigger: Trigger<SqlxEvent<Sqlite, C>>)
-{
-    dbg!({ "observe"; trigger.event().label() });
-}
-
-macro_rules! dbg_query {
-    ($label:literal, $query:expr) => {{
-        for entity in &mut $query.iter() {
-            dbg!({ $label; &entity });
-        }
-    }}
-}
-
 fn detect_changed(
     foo_query: Query<(Entity, &Foo), Changed<Foo>>,
     bar_query: Query<(Entity, &Bar), Changed<Bar>>,
 ) {
-    dbg_query!("foo changed", &foo_query);
-    dbg_query!("bar changed", &bar_query);
+    for foo in &foo_query {
+        dbg!({ "foo changed"; &foo});
+    }
+    for bar in &bar_query {
+        dbg!({ "bar changed"; &bar});
+    }
 }
 
 fn detect_removals(

--- a/examples/sqlite/debug.rs
+++ b/examples/sqlite/debug.rs
@@ -146,12 +146,6 @@ impl BarPlugin {
     }
 }
 
-fn handle_trigger<C: SqlxComponent<SqliteRow>>
-(trigger: Trigger<SqlxEvent<Sqlite, C>>)
-{
-    dbg!({ "trigger"; trigger.event().label() });
-}
-
 fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
@@ -161,7 +155,6 @@ fn main() {
         .register_type::<Foo>()
         .register_type::<Bar>()
         .add_systems(Update, (watch_status,
-                              detect_added,
                               detect_changed,
                               detect_removals))
         .run();
@@ -169,8 +162,14 @@ fn main() {
 
 fn watch_status(mut statuses: EventReader<SqlxEventStatus<Sqlite, Foo>>) {
     for status in statuses.read() {
-        dbg!(status);
+        dbg!({ "status"; status });
     }
+}
+
+fn handle_trigger<C: SqlxComponent<SqliteRow>>
+(trigger: Trigger<SqlxEvent<Sqlite, C>>)
+{
+    dbg!({ "observe"; trigger.event().label() });
 }
 
 macro_rules! dbg_query {
@@ -179,14 +178,6 @@ macro_rules! dbg_query {
             dbg!({ $label; &entity });
         }
     }}
-}
-
-fn detect_added(
-    foo_query: Query<(Entity, &Foo), Added<Foo>>,
-    bar_query: Query<(Entity, &Bar), Added<Bar>>,
-) {
-    dbg_query!("foo added", &foo_query);
-    dbg_query!("bar added", &bar_query);
 }
 
 fn detect_changed(

--- a/examples/sqlite/debug.rs
+++ b/examples/sqlite/debug.rs
@@ -3,7 +3,13 @@ use rand::prelude::*;
 use bevy::prelude::*;
 use bevy_inspector_egui::quick::WorldInspectorPlugin;
 use sqlx::{FromRow, Sqlite, sqlite::SqliteRow};
-use bevy_sqlx::{SqlxPlugin, SqlxEvent, SqlxComponent, PrimaryKey};
+use bevy_sqlx::{
+    SqlxPlugin,
+    SqlxEvent,
+    SqlxEventStatus,
+    SqlxComponent,
+    PrimaryKey,
+};
 
 #[derive(Reflect, Component, FromRow, Debug, Default, Clone)]
 #[allow(unused)]
@@ -154,10 +160,17 @@ fn main() {
         .add_plugins(BarPlugin)
         .register_type::<Foo>()
         .register_type::<Bar>()
-        .add_systems(Update, (detect_added,
+        .add_systems(Update, (watch_status,
+                              detect_added,
                               detect_changed,
                               detect_removals))
         .run();
+}
+
+fn watch_status(mut statuses: EventReader<SqlxEventStatus<Sqlite, Foo>>) {
+    for status in statuses.read() {
+        dbg!(status);
+    }
 }
 
 macro_rules! dbg_query {

--- a/src/component.rs
+++ b/src/component.rs
@@ -34,7 +34,7 @@ where
 //
 // TODO: Look into impl PartialEq<PrimaryKey<...>> for Foo
 pub trait PrimaryKey {
-    type Column: PartialEq;
+    type Column: Clone + PartialEq + Send + Sync;
     // fn primary_key_name() -> &'static str;
     fn primary_key(&self) -> Self::Column;
 }

--- a/src/event.rs
+++ b/src/event.rs
@@ -129,7 +129,7 @@ where
 pub enum SqlxEventStatus<DB: Database, C: SqlxComponent<DB::Row>> {
     Started(Option<String>),
     Spawn(C::Column, PhantomData<DB>),
-    Insert(C::Column, PhantomData<DB>),
+    Update(C::Column, PhantomData<DB>),
     // TODO: how to support delete?
     Error(Error),
 }

--- a/src/event.rs
+++ b/src/event.rs
@@ -130,7 +130,6 @@ pub enum SqlxEventStatus<DB: Database, C: SqlxComponent<DB::Row>> {
     Started(Option<String>),
     Spawn(C::Column, PhantomData<DB>),
     Update(C::Column, PhantomData<DB>),
-    // TODO: how to support delete?
     Error(Error),
 }
 

--- a/src/event.rs
+++ b/src/event.rs
@@ -125,13 +125,13 @@ where
     }
 }
 
-#[derive(Event, Debug, PartialEq)]
+#[derive(Event, Debug)]
 pub enum SqlxEventStatus<DB: Database, C: SqlxComponent<DB::Row>> {
     Started(Option<String>),
     Spawn(C::Column, PhantomData<DB>),
     Insert(C::Column, PhantomData<DB>),
     // TODO: how to support delete?
-    Error,
+    Error(Error),
 }
 
 impl<DB: Database + Sync, C: SqlxComponent<DB::Row>> SqlxEvent<DB, C>

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,11 +47,11 @@
 pub mod component;
 pub use self::component::*;
 
+pub mod event;
+pub use self::event::*;
+
 mod database;
 pub use self::database::*;
-
-mod event;
-pub use self::event::*;
 
 mod plugin;
 pub use self::plugin::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+#![feature(assert_matches)]
 //! Bevy SQLx is a database plugin for Bevy's ECS which allows for SQL queries
 //! to be performed and data entities to be spawned and managed.
 //!

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -48,6 +48,7 @@ where
         });
         app.insert_resource(SqlxTasks::<DB, C>::default());
         app.add_event::<SqlxEvent<DB, C>>();
+        app.add_event::<SqlxEventStatus<DB, C>>();
         app.add_systems(Update, SqlxEvent::<DB, C>::handle_events);
         app.add_systems(Update, SqlxTasks::<DB, C>::handle_tasks);
     }

--- a/src/tasks.rs
+++ b/src/tasks.rs
@@ -56,7 +56,6 @@ where
                         // TODO: Look into world.spawn_batch after taking set
                         // disjunction of ids.
                         for task_component in task_components {
-
                             // Check if the task's component is already spawned.
                             let mut existing_entity = None;
                             for (entity, spawned_component) in &mut query {

--- a/src/tasks.rs
+++ b/src/tasks.rs
@@ -50,10 +50,7 @@ where
         // }
 
         tasks.components.retain_mut(|(label, task)| {
-            let poll = block_on(future::poll_once(task));
-            // TODO refactor to remove this variable
-            let retain = poll.is_none();
-            if let Some(result) = poll {
+            block_on(future::poll_once(task)).map(|result| {
                 match result {
                     Ok(task_components) => {
                         // TODO: Look into world.spawn_batch after taking set
@@ -92,8 +89,7 @@ where
                         status.send(SqlxEventStatus::Error(err));
                     }
                 }
-            }
-            retain
+            }).is_none()
         });
 
         params.apply(world);

--- a/src/tasks.rs
+++ b/src/tasks.rs
@@ -72,13 +72,11 @@ where
                             }
 
                             if let Some(entity) = existing_entity {
-                                dbg!("sending insert");
                                 status.send(SqlxEventStatus::
                                     Insert(task_component.primary_key(),
                                             PhantomData));
                                 commands.entity(entity).insert(task_component);
                             } else {
-                                dbg!("sending spawn");
                                 status.send(SqlxEventStatus::
                                     Spawn(task_component.primary_key(),
                                             PhantomData));
@@ -87,6 +85,7 @@ where
                         }
                     }
                     Err(err) => {
+                        // TODO: pass the error
                         dbg!(err);
                         status.send(SqlxEventStatus::Error);
                     }

--- a/src/tasks.rs
+++ b/src/tasks.rs
@@ -85,9 +85,7 @@ where
                         }
                     }
                     Err(err) => {
-                        // TODO: pass the error
-                        dbg!(err);
-                        status.send(SqlxEventStatus::Error);
+                        status.send(SqlxEventStatus::Error(err));
                     }
                 }
             }

--- a/src/tasks.rs
+++ b/src/tasks.rs
@@ -73,7 +73,7 @@ where
 
                             if let Some(entity) = existing_entity {
                                 status.send(SqlxEventStatus::
-                                    Insert(task_component.primary_key(),
+                                    Update(task_component.primary_key(),
                                             PhantomData));
                                 commands.entity(entity).insert(task_component);
                             } else {


### PR DESCRIPTION
Fixes #5

Example of using new `SqlxEventStatus` event.
```rust
fn watch_status(mut statuses: EventReader<SqlxEventStatus<Sqlite, Foo>>) {
    for status in statuses.read() {
        match status {
            Started(label) => { ... },
            Spawn(pk, _)   => { ... }
            Insert(pk, _)  => { ... },
            Error(e)       => { ... },
        }
    }
}
```